### PR TITLE
Add new routes for donor pages that support UID and name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fah-stats",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fah-stats",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "homepage": "/",
   "scripts": {

--- a/src/modules/Donor/AllTime/DonorAllTime.jsx
+++ b/src/modules/Donor/AllTime/DonorAllTime.jsx
@@ -39,7 +39,7 @@ const DonorAllTime = () => {
       fixed: 'left',
       render: (text, data) => (
         <span css={styles.dNameIdContainer}>
-          <Link css={styles.dName} to={`/donor/${data.id}`}>{text}</Link>
+          <Link css={styles.dName} to={`/donor/id/${data.id}`}>{text}</Link>
           <span css={styles.dId}>{data.id}</span>
         </span>
       ),

--- a/src/modules/Donor/DonorProfile.jsx
+++ b/src/modules/Donor/DonorProfile.jsx
@@ -6,10 +6,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 const DonorProfile = () => {
   const dispatch = useDispatch();
-  const { id } = useParams();
+  const { id, name } = useParams();
 
   useEffect(() => {
-    dispatch(getDonorProfile({ donorId: id }));
+    dispatch(getDonorProfile({ donorId: id, donorName: name }));
   }, []);
 
   const stats = useSelector((state) => state.stats);

--- a/src/modules/Donor/Monthly/DonorMonthly.jsx
+++ b/src/modules/Donor/Monthly/DonorMonthly.jsx
@@ -85,7 +85,7 @@ const DonorMonthly = () => {
       fixed: 'left',
       render: (text, data) => (
         <span css={styles.dNameIdContainer}>
-          <Link css={styles.dName} to={`/donor/${data.id}`}>{text}</Link>
+          <Link css={styles.dName} to={`/donor/id/${data.id}`}>{text}</Link>
           <span css={styles.dId}>{data.id}</span>
         </span>
       ),

--- a/src/modules/Donor/Monthly/DonorMonthlyMini.jsx
+++ b/src/modules/Donor/Monthly/DonorMonthlyMini.jsx
@@ -90,7 +90,7 @@ const DonorMonthlyMini = () => {
       width: 200,
       render: (text, data) => (
         <span css={styles.dNameIdContainer}>
-          <Link css={styles.dName} to={`/donor/${data.id}`}>{text}</Link>
+          <Link css={styles.dName} to={`/donor/id/${data.id}`}>{text}</Link>
           <span css={styles.dId}>{data.id}</span>
         </span>
       ),

--- a/src/modules/Team/TeamMembers.jsx
+++ b/src/modules/Team/TeamMembers.jsx
@@ -41,7 +41,7 @@ const teamMembers = () => {
       fixed: 'left',
       render: (text, data) => (
         <span css={styles.dNameIdContainer}>
-          <Link css={styles.dName} to={`/donor/${data.id}`}>{text}</Link>
+          <Link css={styles.dName} to={`/donor/id/${data.id}`}>{text}</Link>
           <span css={styles.dId}>{data.id}</span>
         </span>
       ),

--- a/src/utils/Routes.jsx
+++ b/src/utils/Routes.jsx
@@ -31,6 +31,12 @@ const Routes = () => (
     <Route exact path="/donor/:id">
       <DonorProfile />
     </Route>
+    <Route exact path="/donor/id/:id">
+      <DonorProfile />
+    </Route>
+    <Route exact path="/donor/name/:name">
+      <DonorProfile />
+    </Route>
     <Route exact path="/project">
       <Project />
     </Route>

--- a/src/utils/Routes.jsx
+++ b/src/utils/Routes.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Switch,
   Route,
+  Redirect,
 } from 'react-router-dom';
 import Home from 'modules/Home/Home';
 import Missing from 'modules/Home/Missing';
@@ -28,15 +29,13 @@ const Routes = () => (
     <Route exact path="/donor">
       <Donor />
     </Route>
-    <Route exact path="/donor/:id">
-      <DonorProfile />
-    </Route>
     <Route exact path="/donor/id/:id">
       <DonorProfile />
     </Route>
     <Route exact path="/donor/name/:name">
       <DonorProfile />
     </Route>
+    <Redirect from="/donor/:id" to="/donor/id/:id" />
     <Route exact path="/project">
       <Project />
     </Route>


### PR DESCRIPTION
See https://github.com/FoldingCommunity/fah-stats-front-end/issues/65.

Added routes for looking donors up by name as well as UID. For completeness, the old route is:
/donor/:id
And the new routes are:
/donor/id/:id
/donor/name/:name

The old route redirects to the new UID route. User names with spaces work as expected.