### PR TITLE
Ignore "css" for linting rule "react/no-unknown-property"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
   ],
   rules: {
     'linebreak-style': 0,
+    'react/no-unknown-property': ['error', { ignore: ['css'] }],
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
Added ignore rule in .eslintrc.js to bypass these errors : 
![no-unknown-property](https://user-images.githubusercontent.com/54511523/210131953-fa4f4cd0-d587-4883-8398-6d8bf17baba9.png)
src : https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
