### PR TITLE
Fix searching donor name with "exotic" characters in getDonorByNameId

### DIFF
--- a/src/store/stats/actions.js
+++ b/src/store/stats/actions.js
@@ -242,7 +242,7 @@ const getDonorByNameId = ({
     if (computedDonorId) {
       res = await fetch.get(`${apiHostRead}/uid/${computedDonorId}`);
     } else if (computedDonorName) {
-      res = await fetch.get(`${apiHostRead}/user/${computedDonorName}`);
+      res = await fetch.get(`${apiHostRead}/user/${encodeURIComponent(computedDonorName)}`);
     }
 
     const formattedRes = formatResult(res, true);


### PR DESCRIPTION
Encode donor name to fix UI search  and direct URL access,  for donor name with "non standard" characters

**UI search :**
![exotic_char](https://user-images.githubusercontent.com/54511523/210132285-7324f3ab-e260-4ee2-898c-cf0bc9602b3a.png)

**API access :**
![exotic_char2](https://user-images.githubusercontent.com/54511523/210132294-8a792a2a-3803-4b69-bc25-e89db26a38e0.png)

**Stats URL :**
![exotic_char4](https://user-images.githubusercontent.com/54511523/210132296-77a13d75-e6fc-4a94-95b6-7d44f16db922.png)

Tested with several "exotic" names found : 
```
_-=[Chris]=-_ 
./fah6_-configonly_-smp
"(Inpact)_aeolys"
(^(**TuRkIsh__--__StYLe**)^)
[>-__B]_MieL```