### PR TITLE
Add Rank column to All-Time view in both donor and team statistics

### DIFF
--- a/src/modules/Donor/AllTime/DonorAllTime.jsx
+++ b/src/modules/Donor/AllTime/DonorAllTime.jsx
@@ -32,6 +32,13 @@ const DonorAllTime = () => {
   const stats = useSelector((state) => state.stats);
   const columns = [
     {
+      title: 'Rank',
+      fixed: 'left',
+      width: 50,
+      render: (data) => (stats?.donor.indexOf(data) + 1),
+      sorter: (a, b) => a.credit - b.credit,
+    },
+    {
       title: 'Donor Name',
       dataIndex: 'name',
       key: 'name',

--- a/src/modules/Team/AllTime/TeamAllTime.jsx
+++ b/src/modules/Team/AllTime/TeamAllTime.jsx
@@ -39,6 +39,13 @@ const TeamAllTime = () => {
   const stats = useSelector((state) => state.stats);
   const columns = [
     {
+      title: 'Rank',
+      fixed: 'left',
+      width: 50,
+      render: (data) => (stats?.team.indexOf(data) + 1),
+      sorter: (a, b) => a.credit - b.credit,
+    },
+    {
       title: 'Team Name',
       dataIndex: 'name',
       key: 'name',

--- a/src/modules/Team/TeamMembers.jsx
+++ b/src/modules/Team/TeamMembers.jsx
@@ -25,7 +25,14 @@ const teamMembers = () => {
   const stats = useSelector((state) => state.stats);
   const columns = [
     {
-      title: 'Rank',
+      title: 'Rank (team)',
+      fixed: 'left',
+      width: 50,
+      render: (text, data) => (stats?.teamMembers.indexOf(data) + 1),
+      sorter: (a, b) => a.score - b.score,
+    },
+    {
+      title: 'Rank (project)',
       dataIndex: 'rank',
       key: 'rank',
       fixed: 'left',


### PR DESCRIPTION
-Add Rank column to All-Time view in both donor and team statistics (issue #74)
![rank_all-time_users](https://user-images.githubusercontent.com/54511523/210132451-6a089069-b287-4d68-8f2e-eb621984df97.png)
![rank_all-time_teams](https://user-images.githubusercontent.com/54511523/210132449-64d2f651-b210-4a64-b233-98cad045c603.png)

-Add Rank column (donor rank in team) in Team Donors list
_nb: I used the same wording than EOC stats for these 2 "rank" columns_
![rank_internal](https://user-images.githubusercontent.com/54511523/210132490-9af6dc32-510c-47b3-b092-630153f12013.png)

`/!\` I never used Ant Design tables so I am not sure this code is the best way to implement this (or even correct!). 
But so far, it seems to work as intended.
An in-depth review might be needed for this one !

